### PR TITLE
add sync_channel and SyncSender support

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -14,6 +14,18 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
     (Sender { waker: waker.clone(), tx }, Receiver { waker, rx })
 }
 
+/// Create a pair of the [`SyncSender`] and the [`Receiver`].
+///
+/// The [`Receiver`] implements the [`event::Source`] so that it can be registered
+/// with the [`mio::poll::Poll`], while the [`Sender`] doesn't.
+pub fn sync_channel<T>(bound: usize) -> (SyncSender<T>, Receiver<T>) {
+    let (tx, rx) = mpsc::sync_channel(bound);
+
+    let waker = Arc::new(Mutex::new(None));
+
+    (SyncSender { waker: waker.clone(), tx }, Receiver { waker, rx })
+}
+
 /// A wrapper of the [`mpsc::Receiver`].
 /// 
 /// It implements the [`event::Source`] so that it can be registered with the [`mio::poll::Poll`].
@@ -92,6 +104,35 @@ impl<T> Sender<T> {
 }
 
 impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        Self { waker: self.waker.clone(), tx: self.tx.clone() }
+    }
+}
+
+/// A wrapper of the [`mpsc::SyncSender`].
+pub struct SyncSender<T> {
+    waker: Arc<Mutex<Option<Waker>>>,
+    tx: mpsc::SyncSender<T>
+}
+
+impl<T> SyncSender<T> {
+    /// Try to send a value. It works just like [`mpsc::SyncSender::send`].
+    /// After sending it, it's waking upthe [`mio::poll::Poll`].
+    ///
+    /// Note that it does not return any I/O error even if it occurs
+    /// when waking up the [`mio::poll::Poll`].
+    pub fn send(&self, t: T) -> Result<(), mpsc::SendError<T>> {
+        self.tx.send(t)?;
+
+        if let Some(waker) = &mut *self.waker.lock().unwrap() {
+            let _ = waker.wake();
+        }
+
+        Ok(())
+    }
+}
+
+impl<T> Clone for SyncSender<T> {
     fn clone(&self) -> Self {
         Self { waker: self.waker.clone(), tx: self.tx.clone() }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,4 +38,4 @@
 
 mod channel;
 
-pub use channel::{channel, Sender, Receiver};
+pub use channel::{channel, sync_channel, Sender, SyncSender, Receiver};


### PR DESCRIPTION
## Background Info
I would like to use SyncSender with mio v0.8.
I looked for mio v0.8 wrapper of SyncSender but, I couldn't find it.

## Changes
add sync_channel and SyncSender